### PR TITLE
Fix long string delimiter optimization

### DIFF
--- a/luasrcdiet/optlex.lua
+++ b/luasrcdiet/optlex.lua
@@ -490,7 +490,7 @@ local function do_lstring(I)
     -- loop to test ending delimiter with less of '=' down to zero
     while chk >= 2 do
       local delim = "%]"..rep("=", chk - 2).."%]"
-      if not match(y, delim) then okay = chk end
+      if not match(y.."]", delim) then okay = chk end
       chk = chk - 1
     end
     if okay then  -- change delimiters


### PR DESCRIPTION
When testing if a shorter long string delimiter can be used
for a string `str`, search for the ending delimiter in
`str.."]"` instead of `str`, to detect case when `str` ends
in an almost-complete delimiter without the last bracket.

Testcase:

```lua
return [=[]]=]
```

is now unchanged instead of being optimized to
syntactically incorrect

```lua
return [[]]]
```
